### PR TITLE
fix infinite undefined errors when provided root doesn't have the required descendant nodes

### DIFF
--- a/jquery.tinyscrollbar.js
+++ b/jquery.tinyscrollbar.js
@@ -49,6 +49,10 @@
       return self.contentRatio < 1;
     }
     function initialize() {
+      if (!(viewport.length && content.length && scrollbar.length && track.length && thumb.length)) {
+        return null;
+      }
+
       self.update();
       setEvents();
       return self;


### PR DESCRIPTION
I expected if the required structure isn't provided for tinyscrollbar that calling `.tinyscrollbar` would cause nothing to happen, same as operating on non-existant elements in jQuery (e.g. `$('.some .empty. .selection').fadeIn(); // does nothing`). However it causes infinite "is undefined" errors instead.

In my patch, maybe returning null isn't the best, as the caller's interface should be fluent, but typical usage is just `$('#some_scroll').tinyscrollbar();` without chaining.
